### PR TITLE
Test on JVM firestore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,12 @@ ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "io.chrisdavenport"
 ThisBuild / organizationName := "Christopher Davenport"
 
-enablePlugins(ScalaNativePlugin)
+// enablePlugins(ScalaNativePlugin)
 
 name := "Scala Native Ember Example"
 
 libraryDependencies ++= Seq(
-  "com.armanbilge" %%% "epollcat" % "0.1.6", // Runtime
+  // "com.armanbilge" %%% "epollcat" % "0.1.6", // Runtime
   "org.http4s" %%% "http4s-ember-client" % "0.23.23",
   "org.http4s" %%% "http4s-ember-server" % "0.23.23",
   "org.http4s" %%% "http4s-dsl" % "0.23.23",
@@ -21,28 +21,27 @@ libraryDependencies ++= Seq(
 val isLinux = Option(System.getProperty("os.name")).exists(_.toLowerCase().contains("linux"))
 val isMacOs = Option(System.getProperty("os.name")).exists(_.toLowerCase().contains("mac"))
 val isArm = Option(System.getProperty("os.arch")).exists(_.toLowerCase().contains("aarch64"))
-val s2nLibPath = sys.env.get("S2N_LIBRARY_PATH")
-
-
-
-nativeConfig ~= { c =>
-  val linkOpts = ListBuffer.empty[String]
-  if (isLinux) // brew-installed s2n
-    linkOpts.append("-L/home/linuxbrew/.linuxbrew/lib")
-  else if (isMacOs) // brew-installed OpenSSL
-    if(isArm) linkOpts.append("-L/opt/homebrew/opt/openssl@3/lib")
-    else linkOpts.append("-L/usr/local/opt/openssl@3/lib")
-  s2nLibPath match {
-    case None =>
-    case Some(path) => linkOpts.append(s"-L$path")
-  }
-  c.withLinkingOptions(c.linkingOptions ++ linkOpts.toSeq)
-}
-
-envVars ++= {
-  val ldLibPath =
-    if (isLinux)
-      Map("LD_LIBRARY_PATH" -> "/home/linuxbrew/.linuxbrew/lib")
-    else Map("LD_LIBRARY_PATH" -> "/usr/local/opt/openssl@1.1/lib")
-  Map("S2N_DONT_MLOCK" -> "1") ++ ldLibPath
-}
+// val s2nLibPath = sys.env.get("S2N_LIBRARY_PATH")
+// 
+// nativeConfig ~= { c =>
+//   val linkOpts = ListBuffer.empty[String]
+//   if (isLinux) // brew-installed s2n
+//     linkOpts.append("-L/home/linuxbrew/.linuxbrew/lib")
+//   else if (isMacOs) // brew-installed OpenSSL
+//     if(isArm) linkOpts.append("-L/opt/homebrew/opt/openssl@3/lib")
+//     else linkOpts.append("-L/usr/local/opt/openssl@3/lib")
+//   s2nLibPath match {
+//     case None =>
+//     case Some(path) => linkOpts.append(s"-L$path")
+//   }
+//   c.withLinkingOptions(c.linkingOptions ++ linkOpts.toSeq)
+// }
+// 
+// envVars ++= {
+//   val ldLibPath =
+//     if (isLinux)
+//       Map("LD_LIBRARY_PATH" -> "/home/linuxbrew/.linuxbrew/lib")
+//     else Map("LD_LIBRARY_PATH" -> "/usr/local/opt/openssl@1.1/lib")
+//   Map("S2N_DONT_MLOCK" -> "1") ++ ldLibPath
+// }
+// 

--- a/src/main/scala/example/EmberExample.scala
+++ b/src/main/scala/example/EmberExample.scala
@@ -11,9 +11,9 @@ import org.http4s.syntax.all._
 import org.http4s.circe._
 import org.http4s.dsl.request._
 import io.circe._
-import epollcat.EpollApp
+// import epollcat.EpollApp
 import fs2.io.net.Network
-import fs2.io.net.tls.S2nConfig
+// import fs2.io.net.tls.S2nConfig
 import fs2.io.net.tls.TLSContext
 import com.comcast.ip4s._
 import com.google.firestore.v1.firestore.Firestore
@@ -31,7 +31,7 @@ import com.google.firestore.v1.firestore.ListCollectionIdsRequest
 import com.google.firestore.v1.firestore.GetDocumentRequest
 import com.google.firestore.v1.firestore.GetDocumentRequest.ConsistencySelector
 
-object EmberExample extends EpollApp {
+object EmberExample extends IOApp {
 
   final case class Joke(joke: String)
   object Joke {
@@ -42,8 +42,8 @@ object EmberExample extends EpollApp {
 
   def run(args: List[String]): IO[ExitCode] =
     val clients = for {
-      tls <- customTLS
-      tlsClient <- createClient(tls)
+      // tls <- customTLS
+      tlsClient <- createClient()
     } yield tlsClient
 
     clients
@@ -130,20 +130,19 @@ object EmberExample extends EpollApp {
       .expect[Joke](Request(Method.GET, uri"https://icanhazdadjoke.com/"))
       .map(_.joke)
 
-  def createClient(tlsContext: TLSContext[IO]): Resource[IO, Client[IO]] = {
+  def createClient(): Resource[IO, Client[IO]] = {
     EmberClientBuilder
       .default[IO]
-      .withTLSContext(tlsContext)
       .withHttp2
       .build
   }
 
   // TLS 1.3 is not supported without a different default
-  def customTLS =
-    S2nConfig.builder
-      .withCipherPreferences("default_tls13")
-      .build[IO]
-      .map(Network[IO].tlsContext.fromS2nConfig(_))
+  // def customTLS =
+  //   S2nConfig.builder
+  //     .withCipherPreferences("default_tls13")
+  //     .build[IO]
+  //     .map(Network[IO].tlsContext.fromS2nConfig(_))
 
   private def createDocumentName(
       projectId: String,


### PR DESCRIPTION
Running https://github.com/tanishiking/scala-native-ember-example/pull/1 on JVM so that we can have decent stacktrace


```sh
❯ sbt
...
sbt:Scala Native Ember Example> run
[info] running example.EmberExample
[WARNING] IOApp `main` is running on a thread other than the main thread.
This may prevent correct resource cleanup after `main` completes.
This condition could be caused by executing `run` in an interactive sbt session with `fork := false`.
Set `Compile / run / fork := true` in this project to resolve this.

To silence this warning set the system property:
`-Dcats.effect.warnOnNonMainThreadDetected=false`.

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

```
$ curl http://localhost:8080/savejoke
```

```
java.util.NoSuchElementException
fs2.Stream$CompileOps.lastOrError$$anonfun$1$$anonfun$1(Stream.scala:4918)
scala.Option.fold(Option.scala:263)
fs2.Stream$CompileOps.lastOrError$$anonfun$1(Stream.scala:4918)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
modify @ fs2.internal.Scope.close(Scope.scala:262)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
rethrow$extension @ fs2.Compiler$Target.compile$$anonfun$1(Compiler.scala:157)
as @ example.EmberExample$.run(EmberExample.scala:53)
get @ org.http4s.ember.core.h2.H2Client$.impl$$anonfun$1(H2Client.scala:343)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Pull$.goCloseScope$1$$anonfun$1$$anonfun$3(Pull.scala:1217)
update @ org.http4s.ember.server.internal.Shutdown$$anon$1.<init>(Shutdown.scala:78)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
```